### PR TITLE
Completely solve the problem of the number of steps in one epoch

### DIFF
--- a/run_class_finetuning.py
+++ b/run_class_finetuning.py
@@ -268,7 +268,9 @@ def main(args, ds_init):
         drop_last=True,
         collate_fn=collate_func,
     )
-
+    
+    num_training_steps_per_epoch = len(data_loader_train)
+    
     if dataset_val is not None:
         data_loader_val = torch.utils.data.DataLoader(
             dataset_val, sampler=sampler_val,
@@ -290,7 +292,7 @@ def main(args, ds_init):
         )
     else:
         data_loader_test = None
-
+    
     mixup_fn = None
     mixup_active = args.mixup > 0 or args.cutmix > 0. or args.cutmix_minmax is not None
     if mixup_active:
@@ -402,7 +404,7 @@ def main(args, ds_init):
     print('number of params:', n_parameters)
 
     total_batch_size = args.batch_size * args.update_freq * utils.get_world_size()
-    num_training_steps_per_epoch = len(dataset_train) // total_batch_size
+
     args.lr = args.lr * total_batch_size / 256
     args.min_lr = args.min_lr * total_batch_size / 256
     args.warmup_lr = args.warmup_lr * total_batch_size / 256

--- a/run_mae_pretraining.py
+++ b/run_mae_pretraining.py
@@ -159,9 +159,6 @@ def main(args):
     global_rank = utils.get_rank()
     sampler_rank = global_rank
 
-    total_batch_size = args.batch_size * num_tasks
-    num_training_steps_per_epoch = len(dataset_train) // total_batch_size
-
     sampler_train = torch.utils.data.DistributedSampler(
         dataset_train, num_replicas=num_tasks, rank=sampler_rank, shuffle=True
     )
@@ -182,14 +179,17 @@ def main(args):
         drop_last=True,
         worker_init_fn=utils.seed_worker
     )
-
+    
+    num_training_steps_per_epoch = len(data_loader_train)
+    
     model.to(device)
     model_without_ddp = model
     n_parameters = sum(p.numel() for p in model.parameters() if p.requires_grad)
 
     print("Model = %s" % str(model_without_ddp))
     print('number of params: {} M'.format(n_parameters / 1e6))
-
+    
+    total_batch_size = args.batch_size * num_tasks
     args.lr = args.lr * total_batch_size / 256
     args.min_lr = args.min_lr * total_batch_size / 256
     args.warmup_lr = args.warmup_lr * total_batch_size / 256


### PR DESCRIPTION
Make `num_training_steps_per_epoch` absolutely consistent with the calculations within the dataloader.